### PR TITLE
fix: Fix rules not matching when it too long

### DIFF
--- a/frontend/src/stores/appSettings.ts
+++ b/frontend/src/stores/appSettings.ts
@@ -1,10 +1,16 @@
 import { ref, watch } from 'vue'
 import { defineStore } from 'pinia'
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 
 import i18n from '@/lang'
-import { debounce, updateTrayMenus, APP_TITLE, APP_VERSION, ignoredError } from '@/utils'
+import {
+  debounce,
+  updateTrayMenus,
+  APP_TITLE,
+  APP_VERSION,
+  ignoredError,
+  stringifyNoFolding
+} from '@/utils'
 import {
   Readfile,
   Writefile,

--- a/frontend/src/stores/appSettings.ts
+++ b/frontend/src/stores/appSettings.ts
@@ -1,6 +1,7 @@
 import { ref, watch } from 'vue'
 import { defineStore } from 'pinia'
-import { parse, stringify } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 
 import i18n from '@/lang'
 import { debounce, updateTrayMenus, APP_TITLE, APP_VERSION, ignoredError } from '@/utils'
@@ -191,7 +192,7 @@ export const useAppSettingsStore = defineStore('app-settings', () => {
       updateAppSettings(settings)
 
       if (!firstOpen) {
-        const lastModifiedConfig = stringify(settings)
+        const lastModifiedConfig = stringifyNoFolding(settings)
         if (latestUserConfig !== lastModifiedConfig) {
           saveAppSettings(lastModifiedConfig).then(() => {
             latestUserConfig = lastModifiedConfig

--- a/frontend/src/stores/plugins.ts
+++ b/frontend/src/stores/plugins.ts
@@ -1,12 +1,11 @@
 import { defineStore } from 'pinia'
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 import { computed, ref, watch } from 'vue'
 
 import { HttpGet, Readfile, Writefile } from '@/bridge'
 import { PluginsFilePath, PluginTrigger, PluginTriggerEvent } from '@/constant'
 import { useAppSettingsStore, type ProfileType, type SubscribeType } from '@/stores'
-import { debounce, omitArray, ignoredError, isNumber, updateTrayMenus } from '@/utils'
+import { debounce, omitArray, ignoredError, isNumber, updateTrayMenus, stringifyNoFolding } from '@/utils'
 
 export type PluginConfiguration = {
   id: string

--- a/frontend/src/stores/plugins.ts
+++ b/frontend/src/stores/plugins.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
-import { parse, stringify } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 import { computed, ref, watch } from 'vue'
 
 import { HttpGet, Readfile, Writefile } from '@/bridge'
@@ -148,7 +149,7 @@ export const usePluginsStore = defineStore('plugins', () => {
 
   const savePlugins = debounce(async () => {
     const p = omitArray(plugins.value, ['key', 'updating', 'loading', 'running'])
-    await Writefile(PluginsFilePath, stringify(p))
+    await Writefile(PluginsFilePath, stringifyNoFolding(p))
   }, 100)
 
   const addPlugin = async (p: PluginType) => {

--- a/frontend/src/stores/profiles.ts
+++ b/frontend/src/stores/profiles.ts
@@ -1,10 +1,9 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 
 import { Readfile, Writefile } from '@/bridge'
-import { debounce, ignoredError } from '@/utils'
+import { debounce, ignoredError, stringifyNoFolding } from '@/utils'
 import {
   TunConfigDefaults,
   ProfilesFilePath,

--- a/frontend/src/stores/profiles.ts
+++ b/frontend/src/stores/profiles.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
-import { parse, stringify } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 
 import { Readfile, Writefile } from '@/bridge'
 import { debounce, ignoredError } from '@/utils'
@@ -152,7 +153,7 @@ export const useProfilesStore = defineStore('profiles', () => {
   }
 
   const saveProfiles = debounce(async () => {
-    await Writefile(ProfilesFilePath, stringify(profiles.value))
+    await Writefile(ProfilesFilePath, stringifyNoFolding(profiles.value))
   }, 100)
 
   const addProfile = async (p: ProfileType) => {

--- a/frontend/src/stores/rulesets.ts
+++ b/frontend/src/stores/rulesets.ts
@@ -1,11 +1,10 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 
 import { RulesetsFilePath, RulesetBehavior, RulesetFormat, EmptyRuleSet } from '@/constant'
 import { Copyfile, Readfile, Writefile, HttpGet, Download, FileExists } from '@/bridge'
-import { debounce, isValidPaylodYAML, ignoredError, omitArray } from '@/utils'
+import { debounce, isValidPaylodYAML, ignoredError, omitArray, stringifyNoFolding } from '@/utils'
 
 export type RuleSetType = {
   id: string

--- a/frontend/src/stores/rulesets.ts
+++ b/frontend/src/stores/rulesets.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
-import { stringify, parse } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 
 import { RulesetsFilePath, RulesetBehavior, RulesetFormat, EmptyRuleSet } from '@/constant'
 import { Copyfile, Readfile, Writefile, HttpGet, Download, FileExists } from '@/bridge'
@@ -31,7 +32,7 @@ export const useRulesetsStore = defineStore('rulesets', () => {
 
   const saveRulesets = debounce(async () => {
     const r = omitArray(rulesets.value, ['updating'])
-    await Writefile(RulesetsFilePath, stringify(r))
+    await Writefile(RulesetsFilePath, stringifyNoFolding(r))
   }, 500)
 
   const addRuleset = async (r: RuleSetType) => {
@@ -84,7 +85,7 @@ export const useRulesetsStore = defineStore('rulesets', () => {
         if (isExist) {
           body = await Readfile(r.path)
         } else {
-          body = stringify(EmptyRuleSet)
+          body = stringifyNoFolding(EmptyRuleSet)
         }
       }
 
@@ -99,7 +100,7 @@ export const useRulesetsStore = defineStore('rulesets', () => {
         (['Http', 'File'].includes(r.type) && r.url !== r.path) ||
         (r.type === 'Manual' && !isExist)
       ) {
-        await Writefile(r.path, stringify(ruleset))
+        await Writefile(r.path, stringifyNoFolding(ruleset))
       }
 
       r.count = ruleset.payload.length

--- a/frontend/src/stores/scheduledtasks.ts
+++ b/frontend/src/stores/scheduledtasks.ts
@@ -1,10 +1,9 @@
 import { defineStore } from 'pinia'
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 import { computed, ref, watch } from 'vue'
 
 import { Notify } from '@/bridge'
-import { debounce, ignoredError } from '@/utils'
+import { debounce, ignoredError, stringifyNoFolding } from '@/utils'
 import { PluginTriggerEvent, ScheduledTasksFilePath, ScheduledTasksType } from '@/constant'
 import { useSubscribesStore, useRulesetsStore, usePluginsStore, useLogsStore } from '@/stores'
 import {

--- a/frontend/src/stores/scheduledtasks.ts
+++ b/frontend/src/stores/scheduledtasks.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
-import { stringify, parse } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 import { computed, ref, watch } from 'vue'
 
 import { Notify } from '@/bridge'
@@ -122,7 +123,7 @@ export const useScheduledTasksStore = defineStore('scheduledtasks', () => {
   }
 
   const saveScheduledTasks = debounce(async () => {
-    await Writefile(ScheduledTasksFilePath, stringify(scheduledtasks.value))
+    await Writefile(ScheduledTasksFilePath, stringifyNoFolding(scheduledtasks.value))
   }, 500)
 
   const addScheduledTask = async (s: ScheduledTaskType) => {

--- a/frontend/src/stores/subscribes.ts
+++ b/frontend/src/stores/subscribes.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
-import { stringify, parse } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 
 import { SubscribesFilePath } from '@/constant'
 import { Readfile, Writefile, HttpGet } from '@/bridge'
@@ -58,7 +59,7 @@ export const useSubscribesStore = defineStore('subscribes', () => {
 
   const saveSubscribes = debounce(async () => {
     const s = omitArray(subscribes.value, ['updating'])
-    await Writefile(SubscribesFilePath, stringify(s))
+    await Writefile(SubscribesFilePath, stringifyNoFolding(s))
   }, 500)
 
   const addSubscribe = async (s: SubscribeType) => {
@@ -229,7 +230,7 @@ export const useSubscribesStore = defineStore('subscribes', () => {
 
     if (s.type === 'Http' || s.url !== s.path) {
       proxies = omitArray(proxies, ['__id__', '__tmp__id__'])
-      await Writefile(s.path, stringify({ proxies }))
+      await Writefile(s.path, stringifyNoFolding({ proxies }))
     }
   }
 

--- a/frontend/src/stores/subscribes.ts
+++ b/frontend/src/stores/subscribes.ts
@@ -1,7 +1,6 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 
 import { SubscribesFilePath } from '@/constant'
 import { Readfile, Writefile, HttpGet } from '@/bridge'
@@ -15,7 +14,8 @@ import {
   ignoredError,
   omitArray,
   isValidBase64,
-  formatDate
+  formatDate,
+  stringifyNoFolding
 } from '@/utils'
 
 export type SubscribeType = {

--- a/frontend/src/utils/generator.ts
+++ b/frontend/src/utils/generator.ts
@@ -1,4 +1,5 @@
-import { parse, stringify } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 
 import { Readfile, Writefile } from '@/bridge'
 import { deepClone, APP_TITLE, deepAssign } from '@/utils'
@@ -341,5 +342,5 @@ export const generateConfigFile = async (profile: ProfileType) => {
 
   const config = await generateConfig(profile)
 
-  await Writefile(KernelConfigFilePath, header + stringify(config))
+  await Writefile(KernelConfigFilePath, header + stringifyNoFolding(config))
 }

--- a/frontend/src/utils/generator.ts
+++ b/frontend/src/utils/generator.ts
@@ -1,8 +1,7 @@
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 
 import { Readfile, Writefile } from '@/bridge'
-import { deepClone, APP_TITLE, deepAssign } from '@/utils'
+import { deepClone, APP_TITLE, deepAssign, stringifyNoFolding } from '@/utils'
 import { KernelConfigFilePath, ProxyGroup } from '@/constant/kernel'
 import { type ProfileType, useSubscribesStore, useRulesetsStore, usePluginsStore } from '@/stores'
 

--- a/frontend/src/utils/helper.ts
+++ b/frontend/src/utils/helper.ts
@@ -1,4 +1,5 @@
-import { parse, stringify } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 
 import { ProxyGroupType } from '@/constant'
 import { useConfirm, useMessage } from '@/hooks'
@@ -376,7 +377,7 @@ export const addToRuleSet = async (ruleset: 'direct' | 'reject' | 'proxy', paylo
   const content = (await ignoredError(Readfile, path)) || '{}'
   const { payload = [] } = parse(content)
   payload.unshift(...payloads)
-  await Writefile(path, stringify({ payload: [...new Set(payload)] }))
+  await Writefile(path, stringifyNoFolding({ payload: [...new Set(payload)] }))
 }
 
 export const exitApp = async () => {

--- a/frontend/src/utils/helper.ts
+++ b/frontend/src/utils/helper.ts
@@ -1,9 +1,8 @@
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 
 import { ProxyGroupType } from '@/constant'
 import { useConfirm, useMessage } from '@/hooks'
-import { ignoredError, APP_TITLE } from '@/utils'
+import { ignoredError, APP_TITLE, stringifyNoFolding } from '@/utils'
 import { deleteConnection, getConnections, useProxy } from '@/api/kernel'
 import { AbsolutePath, Exec, ExitApp, Readfile, Writefile } from '@/bridge'
 import { useAppSettingsStore, useEnvStore, useKernelApiStore, usePluginsStore } from '@/stores'

--- a/frontend/src/utils/others.ts
+++ b/frontend/src/utils/others.ts
@@ -1,6 +1,7 @@
+import { stringify } from 'yaml'
+
 import { useAppSettingsStore } from '@/stores'
 import { APP_TITLE, APP_VERSION } from '@/utils'
-import { stringify } from 'yaml'
 
 export const deepClone = <T>(json: T): T => JSON.parse(JSON.stringify(json))
 

--- a/frontend/src/utils/others.ts
+++ b/frontend/src/utils/others.ts
@@ -1,5 +1,6 @@
 import { useAppSettingsStore } from '@/stores'
 import { APP_TITLE, APP_VERSION } from '@/utils'
+import { stringify } from 'yaml'
 
 export const deepClone = <T>(json: T): T => JSON.parse(JSON.stringify(json))
 
@@ -120,4 +121,9 @@ export const base64Decode = (str: string) => {
       .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
       .join('')
   )
+}
+
+export const stringifyNoFolding = (content: any) => {
+  // Disable string folding
+  return stringify(content, {lineWidth: 0, minContentWidth: 0})
 }

--- a/frontend/src/views/ProfilesView/components/ProfileForm.vue
+++ b/frontend/src/views/ProfilesView/components/ProfileForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { stringify } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 import { ref, inject, type Ref, computed } from 'vue'
 
 import * as Defaults from '@/constant/profile'
@@ -108,7 +108,7 @@ const handleAdd = () => {
 const handlePreview = async () => {
   try {
     const config = await generateConfig(profile.value)
-    alert(profile.value.name, stringify(config))
+    alert(profile.value.name, stringifyNoFolding(config))
   } catch (error: any) {
     message.error(error.message || error)
   }

--- a/frontend/src/views/ProfilesView/components/ProfileForm.vue
+++ b/frontend/src/views/ProfilesView/components/ProfileForm.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { stringifyNoFolding } from '@/utils'
 import { ref, inject, type Ref, computed } from 'vue'
 
 import * as Defaults from '@/constant/profile'
 import { WindowToggleMaximise } from '@/bridge'
 import { useMessage, useAlert, useBool } from '@/hooks'
-import { deepClone, generateConfig, sampleID } from '@/utils'
+import { deepClone, generateConfig, sampleID, stringifyNoFolding } from '@/utils'
 import { type ProfileType, useProfilesStore } from '@/stores'
 
 import GeneralConfig from './GeneralConfig.vue'

--- a/frontend/src/views/ProfilesView/index.vue
+++ b/frontend/src/views/ProfilesView/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { stringify } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 import { useI18n, I18nT } from 'vue-i18n'
 
 import { ClipboardSetText } from '@/bridge'
@@ -60,7 +60,7 @@ const secondaryMenus: Menu[] = [
       const p = profilesStore.getProfileById(id)!
       try {
         const config = await generateConfig(p)
-        const str = stringify(config)
+        const str = stringifyNoFolding(config)
         const ok = await ClipboardSetText(str)
         if (!ok) throw 'ClipboardSetText Error'
         message.success('common.success')
@@ -75,7 +75,7 @@ const secondaryMenus: Menu[] = [
       const p = profilesStore.getProfileById(id)!
       try {
         const config = await generateConfig(p)
-        alert(p.name, stringify(config))
+        alert(p.name, stringifyNoFolding(config))
       } catch (error: any) {
         message.error(error.message || error)
       }

--- a/frontend/src/views/ProfilesView/index.vue
+++ b/frontend/src/views/ProfilesView/index.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import { stringifyNoFolding } from '@/utils'
 import { useI18n, I18nT } from 'vue-i18n'
 
 import { ClipboardSetText } from '@/bridge'
 import { useMessage, useAlert } from '@/hooks'
 import { DraggableOptions, View } from '@/constant'
-import { debounce, deepClone, generateConfig, sampleID } from '@/utils'
+import { debounce, deepClone, generateConfig, sampleID, stringifyNoFolding } from '@/utils'
 import {
   type ProfileType,
   type Menu,

--- a/frontend/src/views/RulesetsView/components/RulesetView.vue
+++ b/frontend/src/views/RulesetsView/components/RulesetView.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 import { ref, computed, inject } from 'vue'
 
 import { useMessage } from '@/hooks'
 import { Readfile, Writefile } from '@/bridge'
 import { DraggableOptions, RulesetBehavior } from '@/constant'
-import { deepClone, ignoredError, isValidIPCIDR } from '@/utils'
+import { deepClone, ignoredError, isValidIPCIDR, stringifyNoFolding } from '@/utils'
 import { type RuleSetType, type Menu, useRulesetsStore } from '@/stores'
 
 interface Props {

--- a/frontend/src/views/RulesetsView/components/RulesetView.vue
+++ b/frontend/src/views/RulesetsView/components/RulesetView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { parse, stringify } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 import { ref, computed, inject } from 'vue'
 
 import { useMessage } from '@/hooks'
@@ -71,7 +72,7 @@ const handleSave = async () => {
   if (!ruleset.value) return
   loading.value = true
   try {
-    await Writefile(ruleset.value.path, stringify({ payload: rulesetList.value }))
+    await Writefile(ruleset.value.path, stringifyNoFolding({ payload: rulesetList.value }))
     handleSubmit()
   } catch (error: any) {
     message.error(error)

--- a/frontend/src/views/RulesetsView/index.vue
+++ b/frontend/src/views/RulesetsView/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { stringifyNoFolding } from '@/utils'
 import { computed, ref } from 'vue'
 import { useI18n, I18nT } from 'vue-i18n'
 
@@ -8,7 +7,7 @@ import { useMessage } from '@/hooks'
 import { DraggableOptions, RulesetFormat } from '@/constant'
 import { Removefile, Writefile, BrowserOpenURL } from '@/bridge'
 import { getProvidersRules, updateProvidersRules } from '@/api/kernel'
-import { debounce, formatRelativeTime, ignoredError, formatDate } from '@/utils'
+import { debounce, formatRelativeTime, ignoredError, formatDate, stringifyNoFolding } from '@/utils'
 import {
   type RuleSetType,
   type Menu,

--- a/frontend/src/views/RulesetsView/index.vue
+++ b/frontend/src/views/RulesetsView/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { stringify } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 import { computed, ref } from 'vue'
 import { useI18n, I18nT } from 'vue-i18n'
 
@@ -121,7 +121,7 @@ const handleClearRuleset = async (id: string) => {
   if (!r) return
 
   try {
-    await Writefile(r.path, stringify({ payload: [] }))
+    await Writefile(r.path, stringifyNoFolding({ payload: [] }))
     await _updateProvidersRules(r.name)
     r.count = 0
     rulesetsStore.editRuleset(r.id, r)

--- a/frontend/src/views/SubscribesView/components/ProxiesEditor.vue
+++ b/frontend/src/views/SubscribesView/components/ProxiesEditor.vue
@@ -2,11 +2,10 @@
 import { ref, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 
 import { useMessage } from '@/hooks'
 import { Readfile, Writefile } from '@/bridge'
-import { deepClone, ignoredError, omitArray, sampleID } from '@/utils'
+import { deepClone, ignoredError, omitArray, sampleID, stringifyNoFolding } from '@/utils'
 import { type SubscribeType, useSubscribesStore } from '@/stores'
 
 interface Props {

--- a/frontend/src/views/SubscribesView/components/ProxiesEditor.vue
+++ b/frontend/src/views/SubscribesView/components/ProxiesEditor.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref, inject } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { parse, stringify } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 
 import { useMessage } from '@/hooks'
 import { Readfile, Writefile } from '@/bridge'
@@ -35,7 +36,7 @@ const handleSave = async () => {
       name: v.name,
       type: v.type
     }))
-    await Writefile(path, stringify({ proxies: omitArray(proxiesWithId, ['__id_in_gui']) }))
+    await Writefile(path, stringifyNoFolding({ proxies: omitArray(proxiesWithId, ['__id_in_gui']) }))
     await subscribeStore.editSubscribe(id, sub.value)
     handleSubmit()
   } catch (error: any) {
@@ -55,7 +56,7 @@ const initProxiesText = async () => {
       ...proxy
     }
   })
-  proxiesText.value = stringify(proxiesWithId)
+  proxiesText.value = stringifyNoFolding(proxiesWithId)
 }
 
 initProxiesText()

--- a/frontend/src/views/SubscribesView/components/ProxiesView.vue
+++ b/frontend/src/views/SubscribesView/components/ProxiesView.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { parse } from 'yaml'
-import { stringifyNoFolding } from '@/utils'
 import { ref, computed, inject } from 'vue'
 
 import { useBool, useMessage } from '@/hooks'
-import { deepClone, ignoredError, sampleID } from '@/utils'
+import { deepClone, ignoredError, sampleID, stringifyNoFolding } from '@/utils'
 import { ProxyTypeOptions, DraggableOptions } from '@/constant'
 import { ClipboardSetText, Readfile, Writefile } from '@/bridge'
 import { type Menu, type SubscribeType, useSubscribesStore } from '@/stores'

--- a/frontend/src/views/SubscribesView/components/ProxiesView.vue
+++ b/frontend/src/views/SubscribesView/components/ProxiesView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { parse, stringify } from 'yaml'
+import { parse } from 'yaml'
+import { stringifyNoFolding } from '@/utils'
 import { ref, computed, inject } from 'vue'
 
 import { useBool, useMessage } from '@/hooks'
@@ -61,7 +62,7 @@ const menus: Menu[] = [
     handler: async (record: SubscribeType['proxies'][0]) => {
       try {
         const proxy = await getProxyByName(record.name)
-        details.value = stringify(proxy)
+        details.value = stringifyNoFolding(proxy)
         isEdit.value = false
         toggleDetails()
       } catch (error: any) {
@@ -74,7 +75,7 @@ const menus: Menu[] = [
     handler: async (record: SubscribeType['proxies'][0]) => {
       try {
         const proxy = await getProxyByName(record.name)
-        await ClipboardSetText(stringify(proxy))
+        await ClipboardSetText(stringifyNoFolding(proxy))
         message.success('common.copied')
       } catch (error: any) {
         message.error(error)
@@ -86,7 +87,7 @@ const menus: Menu[] = [
     handler: async (record: SubscribeType['proxies'][0]) => {
       try {
         const proxy = await getProxyByName(record.name)
-        details.value = stringify(proxy)
+        details.value = stringifyNoFolding(proxy)
         isEdit.value = true
         editId = record.name
         toggleDetails()
@@ -122,7 +123,7 @@ const handleSave = async () => {
       proxies.some((vv) => vv.name === v.name)
     )
     const sortedArray = proxies.map((v) => filteredProxies.find((vv) => vv.name === v.name))
-    await Writefile(path, stringify({ proxies: sortedArray }))
+    await Writefile(path, stringifyNoFolding({ proxies: sortedArray }))
     await subscribeStore.editSubscribe(id, sub.value)
     handleSubmit()
   } catch (error: any) {


### PR DESCRIPTION
This change fixes the issue that some rules not matching. According to https://eemeli.org/yaml/#tostring-options, the `stringify` method breaks the string by default when a single line of rule is too long. But clash core can not parse it.
Globally replaced it to prevent potential bugs. `globalMethods.ts` has not changed for compatibility.