### PR TITLE
feat(settings): add GitHub download proxy for kernel downloads

### DIFF
--- a/frontend/src/hooks/useCoreBranch.ts
+++ b/frontend/src/hooks/useCoreBranch.ts
@@ -37,6 +37,15 @@ const AlphaUrl = 'https://api.github.com/repos/MetaCubeX/mihomo/releases/tags/Pr
 const StablePage = 'https://github.com/MetaCubeX/mihomo/releases/latest'
 const AlphaPage = 'https://github.com/MetaCubeX/mihomo/releases/tag/Prerelease-Alpha'
 
+// Apply GitHub proxy to a URL
+const applyGitHubProxy = (url: string, proxyUrl: string): string => {
+  if (!proxyUrl) return url
+  // Remove trailing slash from proxy URL
+  const proxy = proxyUrl.replace(/\/$/, '')
+  // Prepend proxy URL to the original URL
+  return `${proxy}/${url}`
+}
+
 export const useCoreBranch = (isAlpha = false) => {
   const releaseUrl = isAlpha ? AlphaUrl : StableUrl
 
@@ -100,7 +109,7 @@ export const useCoreBranch = (isAlpha = false) => {
       await MakeDir(CoreWorkingDirectory)
 
       await Download(
-        asset.browser_download_url,
+        applyGitHubProxy(asset.browser_download_url, appSettings.app.githubProxy || ''),
         downloadCacheFile,
         undefined,
         (progress, total) => {
@@ -158,8 +167,9 @@ export const useCoreBranch = (isAlpha = false) => {
     remoteVersionLoading.value = true
     try {
       if (isAlpha) {
+        const versionUrl = 'https://github.com/MetaCubeX/mihomo/releases/download/Prerelease-Alpha/version.txt'
         const { body } = await HttpGet(
-          'https://github.com/MetaCubeX/mihomo/releases/download/Prerelease-Alpha/version.txt',
+          applyGitHubProxy(versionUrl, appSettings.app.githubProxy || ''),
         )
         return body.trim()
       }

--- a/frontend/src/lang/locale/en.ts
+++ b/frontend/src/lang/locale/en.ts
@@ -660,6 +660,10 @@ export default {
       name: 'GitHub REST API Token',
       tips: 'Provides a higher rate limit',
     },
+    githubProxy: {
+      name: 'GitHub Download Proxy',
+      tips: 'Accelerate kernel downloads, leave empty for direct connection',
+    },
   },
   about: {
     new: 'New',

--- a/frontend/src/lang/locale/zh.ts
+++ b/frontend/src/lang/locale/zh.ts
@@ -659,6 +659,10 @@ export default {
       name: 'GitHub REST API 访问令牌',
       tips: '可获得更高的速率限制',
     },
+    githubProxy: {
+      name: 'GitHub 下载加速',
+      tips: '用于加速内核下载，留空则直连',
+    },
   },
   about: {
     new: '新版本',

--- a/frontend/src/stores/appSettings.ts
+++ b/frontend/src/stores/appSettings.ts
@@ -88,6 +88,7 @@ export const useAppSettingsStore = defineStore('app-settings', () => {
     addGroupToMenu: false,
     pluginSettings: {},
     githubApiToken: '',
+    githubProxy: '',
     multipleInstance: false,
     rollingRelease: true,
     debugOutline: false,
@@ -181,9 +182,9 @@ export const useAppSettingsStore = defineStore('app-settings', () => {
         : settings.theme
     let primary, secondary
     if (settings.color === Color.Custom) {
-      ;({ primaryColor: primary, secondaryColor: secondary } = settings)
+      ; ({ primaryColor: primary, secondaryColor: secondary } = settings)
     } else {
-      ;({ primary, secondary } = Colors[settings.color] ?? { primary: '', secondary: '' })
+      ; ({ primary, secondary } = Colors[settings.color] ?? { primary: '', secondary: '' })
     }
     document.documentElement.style.setProperty('--primary-color', primary)
     document.documentElement.style.setProperty('--secondary-color', secondary)

--- a/frontend/src/types/app.d.ts
+++ b/frontend/src/types/app.d.ts
@@ -91,6 +91,7 @@ type AppSettings = {
   addGroupToMenu: boolean
   pluginSettings: Record<string, Record<string, any>>
   githubApiToken: string
+  githubProxy: string
   multipleInstance: boolean
   rollingRelease: boolean
   debugOutline: boolean
@@ -106,17 +107,17 @@ export interface PluginConfiguration {
   description: string
   key: string
   component:
-    | 'CheckBox'
-    | 'CodeViewer'
-    | 'Input'
-    | 'InputList'
-    | 'KeyValueEditor'
-    | 'Radio'
-    | 'Select'
-    | 'MultipleSelect'
-    | 'Switch'
-    | 'ColorPicker'
-    | ''
+  | 'CheckBox'
+  | 'CodeViewer'
+  | 'Input'
+  | 'InputList'
+  | 'KeyValueEditor'
+  | 'Radio'
+  | 'Select'
+  | 'MultipleSelect'
+  | 'Switch'
+  | 'ColorPicker'
+  | ''
   value: any
   options: any[]
 }

--- a/frontend/src/views/SettingsView/components/components/AdvancedSettings.vue
+++ b/frontend/src/views/SettingsView/components/components/AdvancedSettings.vue
@@ -97,6 +97,28 @@ const handleClearUserAgent = () => {
     </div>
     <div class="px-8 py-12 flex items-center justify-between">
       <div class="text-16 font-bold">
+        {{ $t('settings.githubProxy.name') }}
+        <span class="font-normal text-12">({{ $t('settings.githubProxy.tips') }})</span>
+      </div>
+      <Input
+        v-model.lazy="appSettings.app.githubProxy"
+        :placeholder="'https://ghfast.top'"
+        editable
+        class="text-14 min-w-256"
+      >
+        <template #suffix>
+          <Button
+            @click="appSettings.app.githubProxy = ''"
+            v-tips="'settings.userAgent.reset'"
+            type="text"
+            size="small"
+            icon="reset"
+          />
+        </template>
+      </Input>
+    </div>
+    <div class="px-8 py-12 flex items-center justify-between">
+      <div class="text-16 font-bold">
         {{ $t('settings.multipleInstance') }}
         <span class="font-normal text-12">({{ $t('settings.needRestart') }})</span>
       </div>


### PR DESCRIPTION
Add a new setting option 'GitHub Download Proxy' that allows users to configure a proxy URL to accelerate kernel downloads from GitHub.

This is particularly useful for users in regions where direct access to GitHub has slow download speeds (e.g., China mainland).

Features:

- New setting in Advanced Settings section

- Supports any GitHub mirror/proxy service (e.g., ghfast.top)

- Applied to both stable and alpha kernel downloads

- Leave empty to use direct connection